### PR TITLE
Config unmarshal now returns all field errors

### DIFF
--- a/config/checker.go
+++ b/config/checker.go
@@ -2,45 +2,63 @@ package config
 
 import (
 	"fmt"
-	"github.com/shitpostingio/autopostingbot/config/structs"
 	"reflect"
+
+	"github.com/shitpostingio/autopostingbot/config/structs"
 )
 
 // checkMandatoryFields uses reflection to see if there are
 // mandatory fields with zero value.
+// When using with isReload flag, only checks for fields with reloadable:"true" tag
 func checkMandatoryFields(isReload bool, config structs.Config) error {
-	return checkStruct(isReload, reflect.TypeOf(config), reflect.ValueOf(config))
-}
+	errors := ""
+	for _, err := range checkStruct(isReload, "root", reflect.TypeOf(config), reflect.ValueOf(config)) {
+		errors += fmt.Sprintln(err.Error())
+	}
 
-// checkStruct explores structures recursively and checks if
-// struct fields have a zero value.
-func checkStruct(isReload bool, typeToCheck reflect.Type, valueToCheck reflect.Value) (err error) {
-
-	for i := 0; i < typeToCheck.NumField(); i++ {
-
-		currentField := typeToCheck.Field(i)
-		currentValue := valueToCheck.Field(i)
-
-		switch currentField.Type.Kind() {
-		case reflect.Struct:
-			err = checkStruct(isReload, currentField.Type, currentValue)
-		case reflect.Slice:
-			err = checkSlice(isReload, currentField, currentValue)
-		default:
-			err = checkField(isReload, currentField, currentValue)
-		}
-
-		if err != nil {
-			return
-		}
-
+	if errors != "" {
+		return fmt.Errorf("\n%s", errors)
 	}
 
 	return nil
 }
 
+// checkStruct explores structures recursively and checks if
+// struct fields have a zero value.
+func checkStruct(isReload bool, parent string, typeToCheck reflect.Type, valueToCheck reflect.Value) (errors []error) {
+	errors = make([]error, 0)
+	for i := 0; i < typeToCheck.NumField(); i++ {
+		currentField := typeToCheck.Field(i)
+		currentValue := valueToCheck.Field(i)
+		switch currentField.Type.Kind() {
+		case
+			reflect.Uintptr,
+			reflect.UnsafePointer,
+			reflect.Ptr:
+			continue
+
+		case reflect.Struct:
+			if errs := checkStruct(isReload, currentField.Name, currentField.Type, currentValue); errs != nil {
+				errors = append(errors, errs...)
+			}
+
+		case reflect.Slice:
+			if errs := checkSlice(isReload, fmt.Sprintf("%s in %s", currentField.Name, parent), currentField, currentValue); errs != nil {
+				errors = append(errors, errs...)
+			}
+
+		default:
+			if err := checkField(isReload, parent, currentField, currentValue); err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+
+	return errors
+}
+
 // checkStruct explores slices recursively and checks they have a zero value.
-func checkSlice(isReload bool, typeToCheck reflect.StructField, sliceToCheck reflect.Value) error {
+func checkSlice(isReload bool, parent string, typeToCheck reflect.StructField, sliceToCheck reflect.Value) []error {
 
 	//only check reloadable fields if isReload is true
 	if isReload {
@@ -58,28 +76,27 @@ func checkSlice(isReload bool, typeToCheck reflect.StructField, sliceToCheck ref
 	}
 
 	if sliceToCheck.Len() == 0 {
-		return fmt.Errorf("non optional slice field %s had zero length", typeToCheck.Name)
+		return []error{fmt.Errorf("non optional slice field %s in %s had zero length", typeToCheck.Name, parent)}
 	}
 
-	var err error
+	err := make([]error, 0)
 	for i := 0; i < sliceToCheck.Len(); i++ {
-
 		item := sliceToCheck.Index(i)
 		if item.Kind() == reflect.Struct {
-			err = checkStruct(isReload, reflect.TypeOf(item), reflect.ValueOf(item))
-		} else {
-
-			zeroValue := reflect.Zero(item.Type())
-			if item.Interface() == zeroValue.Interface() {
-				return fmt.Errorf("non optional field %s had zero value at index %d", typeToCheck.Name, i)
+			if errs := checkStruct(isReload, parent, reflect.TypeOf(item.Interface()), reflect.ValueOf(item.Interface())); errs != nil {
+				err = append(err, errs...)
 			}
-
+			continue
 		}
 
-		if err != nil {
-			return err
+		zeroValue := reflect.Zero(item.Type())
+		if item.Interface() == zeroValue.Interface() {
+			err = append(err, fmt.Errorf("non optional field %s had zero value at index %d", typeToCheck.Name, i))
 		}
+	}
 
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -88,8 +105,7 @@ func checkSlice(isReload bool, typeToCheck reflect.StructField, sliceToCheck ref
 
 // checkField checks if a field is optional or a webhook field
 // if it isn't, it checks if the field has a zero value.
-func checkField(isReload bool, typeToCheck reflect.StructField, valueToCheck reflect.Value) error {
-
+func checkField(isReload bool, section string, typeToCheck reflect.StructField, valueToCheck reflect.Value) error {
 	//only check reloadable fields if isReload is true
 	if isReload {
 
@@ -109,7 +125,7 @@ func checkField(isReload bool, typeToCheck reflect.StructField, valueToCheck ref
 	zeroValue := reflect.Zero(typeToCheck.Type)
 
 	if valueToCheck.Interface() == zeroValue.Interface() {
-		return fmt.Errorf("non optional field %s had zero value", typeToCheck.Name)
+		return fmt.Errorf("non optional field %s in section %s had zero value", typeToCheck.Name, section)
 	}
 
 	return nil

--- a/config/checker_test.go
+++ b/config/checker_test.go
@@ -17,7 +17,7 @@ type TestingStruct struct {
 	Optional int `type:"optional"`
 	Webhook  int `type:"webhook"` //same as optional in this context
 
-	Reloadable int `type:"reloadable"`
+	Reloadable int `reloadable:"true"`
 
 	SliceOfPrimitives []int
 	SliceOfStructs    []EmbeddedStruct
@@ -339,6 +339,20 @@ func Test_checkStruct(t *testing.T) {
 				}),
 			},
 			wantErrors: []error{},
+		},
+		{
+			name: "reloadable empty",
+			args: args{
+				isReload:    true,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Reloadable: 0,
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional field Reloadable in section test had zero value"),
+			},
 		},
 		{
 			name: "empty slice in embedded",

--- a/config/checker_test.go
+++ b/config/checker_test.go
@@ -183,7 +183,7 @@ func Test_checkStruct(t *testing.T) {
 					SliceOptional: []int{1},
 				}),
 			},
-			wantErrors: []error{},
+			wantErrors: nil,
 		},
 		{
 			name: "primitive missing",
@@ -271,7 +271,7 @@ func Test_checkStruct(t *testing.T) {
 					},
 				}),
 			},
-			wantErrors: []error{},
+			wantErrors: nil,
 		},
 		{
 			name: "webhook field missing",
@@ -298,7 +298,7 @@ func Test_checkStruct(t *testing.T) {
 					},
 				}),
 			},
-			wantErrors: []error{},
+			wantErrors: nil,
 		},
 		{
 			name: "field missing in embedded struct",
@@ -338,7 +338,7 @@ func Test_checkStruct(t *testing.T) {
 					Reloadable: 1,
 				}),
 			},
-			wantErrors: []error{},
+			wantErrors: nil,
 		},
 		{
 			name: "reloadable empty",

--- a/config/checker_test.go
+++ b/config/checker_test.go
@@ -1,0 +1,441 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/shitpostingio/autopostingbot/config/structs"
+)
+
+type TestingStruct struct {
+	Integer int
+	Float   float32
+	String  string
+	Struct  EmbeddedStruct
+
+	Optional int `type:"optional"`
+	Webhook  int `type:"webhook"` //same as optional in this context
+
+	Reloadable int `type:"reloadable"`
+
+	SliceOfPrimitives []int
+	SliceOfStructs    []EmbeddedStruct
+
+	SliceOptional []int `type:"optional"`
+}
+
+type EmbeddedStruct struct {
+	Primitive int
+	Slice     []int
+}
+
+func Test_checkMandatoryFields(t *testing.T) {
+	type args struct {
+		isReload bool
+		config   structs.Config
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+
+		{
+			name: "without reload - success",
+			args: args{
+				isReload: false,
+				config: structs.Config{
+					Autoposting: structs.AutopostingConfiguration{
+						BotToken:      "token",
+						ChannelID:     -123232,
+						MediaPath:     "/media",
+						Algorithm:     "debug",
+						ChannelHandle: "durov",
+					},
+					Tdlib: structs.TdlibConfiguration{
+						APIId:              1223,
+						APIHash:            "hash",
+						DatabaseDirectory:  "/db",
+						FilesDirectory:     "/files",
+						SystemLanguageCode: "en",
+						DeviceModel:        "test",
+						SystemVersion:      "1.2",
+						ApplicationVersion: "1.4",
+					},
+					DocumentStore: structs.DocumentStoreConfiguration{
+						DatabaseName:   "database_name",
+						AuthMechanism:  "auth",
+						Username:       "username",
+						Password:       "password",
+						AuthSource:     "authsource",
+						ReplicaSetName: "",
+						Hosts:          nil,
+					},
+					AnalysisAPI: structs.AnalysisAPIConfiguration{
+						Address:                  "http://example.com/api",
+						ImageEndpoint:            "http://example.com/api",
+						VideoEndpoint:            "http://example.com/api",
+						AuthorizationHeaderName:  "Bearer",
+						AuthorizationHeaderValue: "token",
+						CallerAPIKeyHeaderName:   "name",
+					},
+					Localization: structs.LocalizationConfiguration{
+						Path:     "/path/to/locale",
+						Language: "en",
+					},
+				},
+			},
+		},
+		{
+			name: "without reload - failure",
+			args: args{
+				isReload: false,
+				config: structs.Config{
+					Autoposting: structs.AutopostingConfiguration{
+						BotToken:      "token",
+						ChannelID:     -123232,
+						MediaPath:     "/media",
+						Algorithm:     "debug",
+						ChannelHandle: "durov",
+					},
+					Tdlib: structs.TdlibConfiguration{
+						APIId:              1223,
+						APIHash:            "hash",
+						DatabaseDirectory:  "/db",
+						FilesDirectory:     "/files",
+						SystemLanguageCode: "en",
+						DeviceModel:        "test",
+						SystemVersion:      "1.2",
+						ApplicationVersion: "1.4",
+					},
+					DocumentStore: structs.DocumentStoreConfiguration{
+						DatabaseName:   "database_name",
+						AuthMechanism:  "auth",
+						Username:       "username",
+						Password:       "password",
+						AuthSource:     "authsource",
+						ReplicaSetName: "",
+						Hosts:          nil,
+					},
+					AnalysisAPI: structs.AnalysisAPIConfiguration{
+						Address:                  "http://example.com/api",
+						ImageEndpoint:            "http://example.com/api",
+						VideoEndpoint:            "http://example.com/api",
+						AuthorizationHeaderName:  "",
+						AuthorizationHeaderValue: "token",
+						CallerAPIKeyHeaderName:   "name",
+					},
+					Localization: structs.LocalizationConfiguration{
+						Path:     "/path/to/locale",
+						Language: "en",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := checkMandatoryFields(tt.args.isReload, tt.args.config); (err != nil) != tt.wantErr {
+				t.Errorf("checkMandatoryFields() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_checkStruct(t *testing.T) {
+	type args struct {
+		isReload     bool
+		parent       string
+		typeToCheck  reflect.Type
+		valueToCheck reflect.Value
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErrors []error
+	}{
+		{
+			name: "all fields are present",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+					SliceOptional: []int{1},
+				}),
+			},
+			wantErrors: []error{},
+		},
+		{
+			name: "primitive missing",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional field String in section test had zero value"),
+			},
+		},
+		{
+			name: "few primitive missing",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 0,
+					Float:   1.2,
+					String:  "",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional field Integer in section test had zero value"),
+				fmt.Errorf("non optional field String in section test had zero value"),
+			},
+		},
+		{
+			name: "optional field missing",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{},
+		},
+		{
+			name: "webhook field missing",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Webhook:           0,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{},
+		},
+		{
+			name: "field missing in embedded struct",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Slice: []int{1},
+					},
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional field Primitive in section Struct had zero value"),
+			},
+		},
+		{
+			name: "reloadable only",
+			args: args{
+				isReload:    true,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Reloadable: 1,
+				}),
+			},
+			wantErrors: []error{},
+		},
+		{
+			name: "empty slice in embedded",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional slice field Slice in Slice in Struct had zero length"),
+			},
+		},
+		{
+			name: "struct field missing in slice",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Slice: []int{1},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional field Primitive in section SliceOfStructs in test had zero value"),
+			},
+		},
+
+		{
+			name: "slice type field empty in one of the structs in slice",
+			args: args{
+				isReload:    false,
+				parent:      "test",
+				typeToCheck: reflect.TypeOf(TestingStruct{}),
+				valueToCheck: reflect.ValueOf(TestingStruct{
+					Integer: 1,
+					Float:   1.2,
+					String:  "str",
+					Struct: EmbeddedStruct{
+						Primitive: 1,
+						Slice:     []int{1},
+					},
+					Optional:          1,
+					Webhook:           1,
+					Reloadable:        1,
+					SliceOfPrimitives: []int{1},
+					SliceOfStructs: []EmbeddedStruct{
+						{
+							Primitive: 1,
+							Slice:     []int{},
+						},
+					},
+				}),
+			},
+			wantErrors: []error{
+				fmt.Errorf("non optional slice field Slice in Slice in SliceOfStructs in test had zero length"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotErrors := checkStruct(tt.args.isReload, tt.args.parent, tt.args.typeToCheck, tt.args.valueToCheck); !reflect.DeepEqual(gotErrors, tt.wantErrors) {
+				t.Errorf("checkStruct() = %v, want %v", gotErrors, tt.wantErrors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since there are quite a lot of optional fields, I suggest adding rich error display, that says exactly what fields are missing.

I also fixed a few bugs that may occur in some specific scenarios in the future and added tests, including tests for configuration struct that is currently being used and for a struct that covers pretty the hardest case I could think of - I'm not sure if it coud be reproduced with toml files, but it's more robust now, that's for sure